### PR TITLE
feat: Allow custom format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [yt-dlp](https://github.com/yt-dlp/yt-dlp) postprocessor [plugin](https://github.com/yt-dlp/yt-dlp#plugins) which sets the mtime of all files to a given datetime value by key.
 
+This postprocessor does not support all possible files output by yt-dlp, namely `*.dump` files.
+
 NOTE: This postprocessor should not be run before files are downloaded.
 
 ## Installation
@@ -18,4 +20,32 @@ See [installing yt-dlp plugins](https://github.com/yt-dlp/yt-dlp#installing-plug
 
 ## Usage
 
-Pass `--use-postprocessor FixupMtime:mtime_key=<key>`, replacing `<key>` with your chosen key to activate the postprocessor e.g. `--use-postprocessor FixupMtime:mtime_key=upload_date`.
+```text
+--use-postprocessor FixupMtime[:;[mtime_key=<key>][mtime_format=<format>]]
+```
+
+Where `<key>` is the key of your desired datetime within the infojson dictionary and `<format>` is the format of the datetime.
+
+The default value for `mtime_key` is `mtime`, which will set the mtime of all files (thumbnails, subtitles etc.) to the existing mtime of the video. If `mtime_key` is `mtime` and `--mtime` was passed to yt-dlp at the time of download, the value will be the datetime of the last-modified header.
+
+The default value for `mtime_format` is `%Y%m%d`. The postprocessor will also attempt to guess the format with yt-dlp's internal list of formats.
+
+## Examples
+
+Set the mtime of all files to the existing mtime of the video:
+
+```text
+--use-postprocessor FixupMtime
+```
+
+Set the mtime of all files to the upload date of the video:
+
+```text
+--use-postprocessor FixupMtime:mtime_key=upload_date
+```
+
+Set the mtime of all files using a custom datetime and format:
+
+```text
+--use-postprocessor FixupMtime:mtime_key=meta_date;mtime_format=%Y-%m-%dT%H.%M.%S
+```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,10 @@
 [metadata]
 name = yt-dlp-FixupMtime
-version = 1.0.0
+version = 1.1.0
 
 [options]
 packages = find_namespace:
+
+[flake8]
+ignore = E402,E501,E731,E741,W503
+max_line_length = 120

--- a/test/test_fixup_mtime.py
+++ b/test/test_fixup_mtime.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+import datetime
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+
+from pathlib import Path
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+from yt_dlp_plugins.postprocessor.fixup_mtime import FixupMtimePP
+
+
+class TestFixupMtimePP(unittest.TestCase):
+    def setUp(self):
+        self.pp = FixupMtimePP()
+
+        # Create a temporary directory of files, set their initial mtime
+        self.temp_dir = tempfile.mkdtemp()
+        self.files = [Path(self.temp_dir, filename) for filename in ['test.mp4', 'test.jpg', 'test.info.json', 'test2.mp4']]
+        self.initial_mtime = 1234567890.0
+        for path in self.files:
+            path.touch()
+            os.utime(path, (self.initial_mtime, self.initial_mtime))
+
+        self.info = {'filepath': self.files[0], 'upload_date': '20120101'}
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test__strptime_or_none_with_invalid_timestamp(self):
+        timestamp = 'foobar'
+        format_code = self.pp._mtime_format
+        expected = None
+        self.assertEqual(self.pp._strptime_or_none(timestamp, format_code), expected)
+
+    def test__strptime_or_none_with_valid_timestamp(self):
+        timestamp = 1672531200.0
+        format_code = self.pp._mtime_format
+        expected = datetime.datetime(year=2023, month=1, day=1, tzinfo=datetime.timezone.utc)
+        self.assertEqual(self.pp._strptime_or_none(timestamp, format_code), expected)
+
+    def test__strptime_or_none_with_valid_string(self):
+        timestamp = '20230101'
+        format_code = self.pp._mtime_format
+        expected = datetime.datetime(year=2023, month=1, day=1)
+        self.assertEqual(self.pp._strptime_or_none(timestamp, format_code), expected)
+
+    def test__strptime_or_none_with_valid_string_and_guess_format(self):
+        timestamp = '2023/01/01'
+        format_code = self.pp._mtime_format
+        expected = datetime.datetime(year=2023, month=1, day=1)
+        self.assertEqual(self.pp._strptime_or_none(timestamp, format_code), expected)
+
+    def test__strptime_or_none_with_valid_string_and_valid_format_code(self):
+        timestamp = '2023-01-01'
+        format_code = '%Y-%m-%d'
+        expected = datetime.datetime(year=2023, month=1, day=1)
+        self.assertEqual(self.pp._strptime_or_none(timestamp, format_code), expected)
+
+    def test__get_related_files(self):
+        filepath = self.info.get('filepath')
+        expected = [path for path in self.files if path.name in ['test.mp4', 'test.jpg', 'test.info.json']]
+        self.assertCountEqual(self.pp._get_related_files(filepath), expected)
+
+    def test__get_mtime_with_existing_mtime(self):
+        filepath = self.info.get('filepath')
+        custom_key = 'mtime'
+        expected = self.initial_mtime
+        self.assertEqual(self.pp._get_mtime(filepath, self.info, custom_key), expected)
+
+    def test__get_mtime_with_custom_key(self):
+        filepath = self.info.get('filepath')
+        custom_key = 'upload_date'
+        expected = self.info.get(custom_key)
+        self.assertEqual(self.pp._get_mtime(filepath, self.info, custom_key), expected)
+
+    def test__get_mtime_with_invalid_key(self):
+        filepath = self.info.get('filepath')
+        custom_key = None
+        expected = None
+        self.assertEqual(self.pp._get_mtime(filepath, self.info, custom_key), expected)
+
+    def test__set_mtime_of_files(self):
+        new_mtime = datetime.datetime(year=2023, month=1, day=1, tzinfo=datetime.timezone.utc)
+        self.pp._set_mtime_of_files(self.files, new_mtime)
+        for path in self.files:
+            self.assertEqual(os.path.getmtime(path), new_mtime.timestamp())
+
+    def test_run(self):
+        self.pp._mtime_key = 'upload_date'
+        self.pp._mtime_format = '%Y%m%d'
+        expected = datetime.datetime(year=2012, month=1, day=1, tzinfo=datetime.timezone.utc).timestamp()
+        self.pp.run(self.info)
+        for path in self.files[:3]:
+            self.assertEqual(os.path.getmtime(path), expected)
+        self.assertNotEqual(os.path.getmtime(self.files[3]), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yt_dlp_plugins/postprocessor/fixup_mtime.py
+++ b/yt_dlp_plugins/postprocessor/fixup_mtime.py
@@ -1,44 +1,56 @@
+import contextlib
 import datetime
+import glob
 import os
+import re
+
+
+from pathlib import Path
+from typing import Iterable, List, Optional, Union
+
+
 from yt_dlp.postprocessor.common import PostProcessor
-from yt_dlp.utils import traverse_obj, datetime_from_str, replace_extension
+from yt_dlp.utils import date_formats
 
 
 class FixupMtimePP(PostProcessor):
-    def __init__(self, downloader=None, mtime_key=None):
+    def __init__(self, downloader=None, mtime_key: str = 'mtime', mtime_format: str = '%Y%m%d') -> None:
         super().__init__(downloader)
         self._mtime_key = mtime_key
+        self._mtime_format = re.sub(r'%%', '%', mtime_format)
 
-    def run(self, info):
+    def _strptime_or_none(self, timestamp: Union[float, int, str], format_code: str) -> Optional[datetime.datetime]:
+        if isinstance(timestamp, (float, int)):
+            return datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
+        for code in [format_code] + date_formats(day_first=True):
+            with contextlib.suppress(ValueError):
+                return datetime.datetime.strptime(timestamp, code)
+        return None
+
+    def _get_related_files(self, filepath: Union[Path, str]) -> List[Path]:
+        if isinstance(filepath, str):
+            filepath = Path(filepath)
+        return [Path(path) for path in filepath.parent.glob(f'{glob.escape(filepath.stem)}.*')
+                if path.is_file()]
+
+    def _get_mtime(self, filepath: Path, info: dict, mtime_key: str) -> Optional[Union[float, int, str]]:
+        return os.path.getmtime(filepath) if mtime_key == 'mtime' else info.get(mtime_key)
+
+    def _set_mtime_of_files(self, files: Iterable[Path], mtime: Union[datetime.datetime, float, int]) -> None:
+        if isinstance(mtime, datetime.datetime):
+            mtime = mtime.timestamp()
+        for path in files:
+            self.try_utime(str(path), os.path.getatime(path), mtime)
+
+    def run(self, info: dict):
         filepath = info.get('filepath')
-
         if filepath:
-            files = {
-                filepath,
-                info.get('__infojson_filename'),
-            }
-
-            if self.get_param('keepvideo', False):
-                for format in traverse_obj(info, ('requested_formats', ...)) or []:
-                    format_id = format.get('format_id')
-                    format_ext = format.get('ext')
-
-                    if format_id and format_ext:
-                        files.add(replace_extension(
-                            filepath, f'f{format_id}.{format_ext}'))
-
-            for path in info.get('__files_to_move'):
-                files.add(path)
-
-            if self.get_param('writedescription', False):
-                files.add(replace_extension(filepath, 'description'))
-
-            mtime = datetime.datetime.fromtimestamp(os.stat(
-                filepath).st_mtime, datetime.timezone.utc) if self._mtime_key == 'mtime' else datetime_from_str(info.get(self._mtime_key))
-
+            mtime = self._strptime_or_none(self._get_mtime(
+                filepath, info, self._mtime_key), self._mtime_format)
             if mtime:
                 self.to_screen(
-                    f'Setting mtime of files to {mtime.isoformat()}')
-                for file in files:
-                    self.try_utime(file, mtime.timestamp(), mtime.timestamp())
+                    f'Setting mtime of files to `{self._mtime_key}` ({mtime.isoformat()})')
+                self._set_mtime_of_files(self._get_related_files(filepath), mtime)
+            else:
+                self.to_screen(f'Unable to set mtime to `{self._mtime_key}`')
         return [], info


### PR DESCRIPTION
Fixes #1

Adds support for optionally specifying a custom format to parse the datetime.

@pke, would you be willing to test this? You can see the changes to the README to see how to use it.