### PR TITLE
fix: Prevent _get_related_files from returning an empty list

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2022]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yt-dlp-fixupmtime"
-version = "1.1.1"
+version = "1.1.2"
 description = "A yt-dlp postprocessor plugin to set the mtime of all files to a given datetime value by key"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Fixes https://github.com/bradenhilton/yt-dlp-FixupMtime/issues/10

I decided to push the fix first, then push the refactored code.

@zxcat Would you mind testing this?